### PR TITLE
Count backers on mount & update to allow for data request by server o…

### DIFF
--- a/client/src/components/NewAndOldBackers.jsx
+++ b/client/src/components/NewAndOldBackers.jsx
@@ -9,8 +9,15 @@ class NewAndOldBackers extends Component {
     };
   }
 
+  componentDidMount() {
+    this.updateBackers();
+  }
 
   componentDidUpdate() {
+    this.updateBackers();
+  }
+
+  updateBackers() {
     const { backers } = this.props;
     let newBackers = 0;
     let oldBackers = 0;
@@ -28,7 +35,6 @@ class NewAndOldBackers extends Component {
       });
     }
   }
-
 
   render() {
     return (


### PR DESCRIPTION
Previously, the code that took in all the backers and updated the count of 'new' and 'old' backers did so on componentDidUpdate, so it wasn't triggered if data was requested on the server side. Changing it to componentDidMount triggers the count on rehydration, but doesn't trigger it on a successful data request. This fix causes it to trigger on either, making it more flexible.